### PR TITLE
chore: fix the pvp infinite interval

### DIFF
--- a/content.js
+++ b/content.js
@@ -9293,6 +9293,13 @@
       
       // Start the interval
       autoSlashInterval = setInterval(() => {
+        const modal = document.querySelector("#endModal");
+        const isShowingEndModal = modal && modal.style.display !== 'none';
+
+        if (isShowingEndModal) {
+          clearInterval(autoSlashInterval);
+        }
+
         if (autoSlashEnabled && slashBtn && !slashBtn.disabled) {
           slashBtn.click();
         }


### PR DESCRIPTION
Check if the battle result modal is showing and clear the interval.